### PR TITLE
prevent "modulo 0" operation

### DIFF
--- a/src/lv_demo_benchmark/lv_demo_benchmark.c
+++ b/src/lv_demo_benchmark/lv_demo_benchmark.c
@@ -997,6 +997,9 @@ static void rnd_reset(void)
 
 static int32_t rnd_next(int32_t min, int32_t max)
 {
+    if(min == max)
+        return min;
+    
     if(min > max) {
         int32_t t = min;
         min = max;


### PR DESCRIPTION
added a min==max guard clause, to prevent a "modulo 0" operation which is undefined and may cause a divide-by-zero exception

this was discovered while running the demo in the Windows Visual Studio simulator: https://github.com/lvgl/lv_sim_visual_studio
