### PR TITLE
fix shadowed tmr variable

### DIFF
--- a/src/lv_demo_stress/lv_demo_stress.c
+++ b/src/lv_demo_stress/lv_demo_stress.c
@@ -250,8 +250,8 @@ static void obj_test_task_cb(lv_timer_t * tmr)
         case 14:
             obj = lv_msgbox_create(NULL, "Title", "Some text on the message box with average length", mbox_btns, true);
 
-            lv_timer_t * tmr = lv_timer_create(msgbox_del, TIME_STEP * 5 + 30, obj);
-            lv_timer_set_repeat_count(tmr, 1);
+            lv_timer_t * msgbox_tmr = lv_timer_create(msgbox_del, TIME_STEP * 5 + 30, obj);
+            lv_timer_set_repeat_count(msgbox_tmr, 1);
             lv_obj_align(obj, LV_ALIGN_RIGHT_MID, -10, 0);
             break;
 


### PR DESCRIPTION
Fix compiler warning "warning: declaration of ‘tmr’ shadows a parameter"