### PR TITLE
use LVGL_DIR path env var

### DIFF
--- a/lv_demo.mk
+++ b/lv_demo.mk
@@ -1,1 +1,1 @@
-CSRCS += $(shell find -L lv_demos -name "*.c")
+CSRCS += $(shell find -L $(LVGL_DIR)/lv_demos -name "*.c")


### PR DESCRIPTION
fixes failed builds when the lv_demos dir is not in the same folder as makefile.
on-par with `lvgl.mk` and `lv_drivers.mk`

Signed-off-by: Sahaj Sarup <sahaj.sarup@linaro.org>