### PR TITLE
fix(CMake) add options, includes and dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,2 +1,21 @@
+cmake_minimum_required(VERSION 3.12.4)
+
+project(lv_demos HOMEPAGE_URL https://github.com/lvgl/lv_demos)
+
+# Option to define LV_DEMO_CONF_INCLUDE_SIMPLE, default: ON
+option(LV_DEMO_CONF_INCLUDE_SIMPLE "Simple include of \"lv_demo_conf.h\"" ON)
+
+# Option to set LV_DEMO_CONF_PATH, if set parent path LV_DEMO_CONF_DIR is added
+# to includes
+option(LV_DEMO_CONF_PATH "Path defined for lv_demo_conf.h")
+get_filename_component(LV_DEMO_CONF_DIR ${LV_DEMO_CONF_PATH} DIRECTORY)
+
 file(GLOB_RECURSE SOURCES src/*.c)
-add_library(lv_examples STATIC ${SOURCES})
+add_library(lv_demos STATIC ${SOURCES})
+add_library(lvgl_demos ALIAS lv_demos)
+add_library(lvgl::demos ALIAS lv_demos)
+
+target_include_directories(lv_demos SYSTEM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+                                                  ${LV_DEMO_CONF_DIR})
+
+target_link_libraries(lv_demos PUBLIC lvgl)


### PR DESCRIPTION
- Added options to modify the following definitions
  - LV_DEMO_CONF_INCLUDE_SIMPLE, default: ON
  - LV_DEMO_CONF_PATH, if defined adds parent folder to include path
    ```CMake
    # Project which includes lvgl sets LV_DEMO_CONF_PATH
    set(LV_DEMO_CONF_PATH
        ${CMAKE_CURRENT_SOURCE_DIR}/src/lv_conf.h
        CACHE STRING "" FORCE)
    ```
- Added dependencies
  - lv_demos depends on lvgl
- Namespaced target aliases
  - lvgl::demos
- Applied cmake-format for a consistent style

This PR is also part of [#2753](https://github.com/lvgl/lvgl/pull/2753)