### PR TITLE
Removed string format warnings for int32_t and uint32_t

### DIFF
--- a/src/lv_demo_benchmark/lv_demo_benchmark.c
+++ b/src/lv_demo_benchmark/lv_demo_benchmark.c
@@ -692,12 +692,12 @@ static void scene_next_task_cb(lv_timer_t * timer)
     }
 
     if(scenes[scene_act].create_cb) {
-        lv_label_set_text_fmt(title, "%"PRId32"/%d: %s%s", scene_act * 2 + (opa_mode ? 1 : 0), (sizeof(scenes) / sizeof(scene_dsc_t) * 2) - 2,  scenes[scene_act].name, opa_mode ? " + opa" : "");
+        lv_label_set_text_fmt(title, "%"LV_PRId32"/%d: %s%s", scene_act * 2 + (opa_mode ? 1 : 0), (sizeof(scenes) / sizeof(scene_dsc_t) * 2) - 2,  scenes[scene_act].name, opa_mode ? " + opa" : "");
         if(opa_mode) {
-            lv_label_set_text_fmt(subtitle, "Result of \"%s\": %"PRId32" FPS", scenes[scene_act].name, scenes[scene_act].fps_normal);
+            lv_label_set_text_fmt(subtitle, "Result of \"%s\": %"LV_PRId32" FPS", scenes[scene_act].name, scenes[scene_act].fps_normal);
         } else {
             if(scene_act > 0) {
-                lv_label_set_text_fmt(subtitle, "Result of \"%s + opa\": %"PRId32" FPS", scenes[scene_act - 1].name, scenes[scene_act - 1].fps_opa);
+                lv_label_set_text_fmt(subtitle, "Result of \"%s + opa\": %"LV_PRId32" FPS", scenes[scene_act - 1].name, scenes[scene_act - 1].fps_opa);
             } else {
                 lv_label_set_text(subtitle, "");
             }
@@ -744,10 +744,10 @@ static void scene_next_task_cb(lv_timer_t * timer)
         lv_obj_set_flex_flow(lv_scr_act(), LV_FLEX_FLOW_COLUMN);
 
         title = lv_label_create(lv_scr_act());
-        lv_label_set_text_fmt(title, "Weighted FPS: %"PRIu32, fps_weighted);
+        lv_label_set_text_fmt(title, "Weighted FPS: %"LV_PRIu32, fps_weighted);
 
         subtitle = lv_label_create(lv_scr_act());
-        lv_label_set_text_fmt(subtitle, "Opa. speed: %"PRIu32"%%", opa_speed_pct);
+        lv_label_set_text_fmt(subtitle, "Opa. speed: %"LV_PRIu32"%%", opa_speed_pct);
 
         lv_coord_t w = lv_obj_get_content_width(lv_scr_act());
         lv_obj_t * table = lv_table_create(lv_scr_act());
@@ -788,7 +788,7 @@ static void scene_next_task_cb(lv_timer_t * timer)
             if(scenes[i].fps_normal < 20 && scenes[i].weight >= 10) {
                 lv_table_set_cell_value(table, row, 0, scenes[i].name);
 
-                lv_snprintf(buf, sizeof(buf), "%"PRIu32, scenes[i].fps_normal);
+                lv_snprintf(buf, sizeof(buf), "%"LV_PRIu32, scenes[i].fps_normal);
                 lv_table_set_cell_value(table, row, 1, buf);
 
 //                lv_table_set_cell_type(table, row, 0, 2);
@@ -801,7 +801,7 @@ static void scene_next_task_cb(lv_timer_t * timer)
                 lv_snprintf(buf, sizeof(buf), "%s + opa", scenes[i].name);
                 lv_table_set_cell_value(table, row, 0, buf);
 
-                lv_snprintf(buf, sizeof(buf), "%"PRIu32, scenes[i].fps_opa);
+                lv_snprintf(buf, sizeof(buf), "%"LV_PRIu32, scenes[i].fps_opa);
                 lv_table_set_cell_value(table, row, 1, buf);
 
 //                lv_table_set_cell_type(table, row, 0, 2);
@@ -826,7 +826,7 @@ static void scene_next_task_cb(lv_timer_t * timer)
         for(i = 0; i < sizeof(scenes) / sizeof(scene_dsc_t) - 1; i++) {
             lv_table_set_cell_value(table, row, 0, scenes[i].name);
 
-            lv_snprintf(buf, sizeof(buf), "%"PRIu32, scenes[i].fps_normal);
+            lv_snprintf(buf, sizeof(buf), "%"LV_PRIu32, scenes[i].fps_normal);
             lv_table_set_cell_value(table, row, 1, buf);
 
             if(scenes[i].fps_normal < 10) {
@@ -843,7 +843,7 @@ static void scene_next_task_cb(lv_timer_t * timer)
             lv_snprintf(buf, sizeof(buf), "%s + opa", scenes[i].name);
             lv_table_set_cell_value(table, row, 0, buf);
 
-            lv_snprintf(buf, sizeof(buf), "%"PRIu32, scenes[i].fps_opa);
+            lv_snprintf(buf, sizeof(buf), "%"LV_PRIu32, scenes[i].fps_opa);
             lv_table_set_cell_value(table, row, 1, buf);
 
 

--- a/src/lv_demo_benchmark/lv_demo_benchmark.c
+++ b/src/lv_demo_benchmark/lv_demo_benchmark.c
@@ -692,12 +692,12 @@ static void scene_next_task_cb(lv_timer_t * timer)
     }
 
     if(scenes[scene_act].create_cb) {
-        lv_label_set_text_fmt(title, "%d/%d: %s%s", scene_act * 2 + (opa_mode ? 1 : 0), (sizeof(scenes) / sizeof(scene_dsc_t) * 2) - 2,  scenes[scene_act].name, opa_mode ? " + opa" : "");
+        lv_label_set_text_fmt(title, "%"PRId32"/%d: %s%s", scene_act * 2 + (opa_mode ? 1 : 0), (sizeof(scenes) / sizeof(scene_dsc_t) * 2) - 2,  scenes[scene_act].name, opa_mode ? " + opa" : "");
         if(opa_mode) {
-            lv_label_set_text_fmt(subtitle, "Result of \"%s\": %d FPS", scenes[scene_act].name, scenes[scene_act].fps_normal);
+            lv_label_set_text_fmt(subtitle, "Result of \"%s\": %"PRId32" FPS", scenes[scene_act].name, scenes[scene_act].fps_normal);
         } else {
             if(scene_act > 0) {
-                lv_label_set_text_fmt(subtitle, "Result of \"%s + opa\": %d FPS", scenes[scene_act - 1].name, scenes[scene_act - 1].fps_opa);
+                lv_label_set_text_fmt(subtitle, "Result of \"%s + opa\": %"PRId32" FPS", scenes[scene_act - 1].name, scenes[scene_act - 1].fps_opa);
             } else {
                 lv_label_set_text(subtitle, "");
             }
@@ -744,10 +744,10 @@ static void scene_next_task_cb(lv_timer_t * timer)
         lv_obj_set_flex_flow(lv_scr_act(), LV_FLEX_FLOW_COLUMN);
 
         title = lv_label_create(lv_scr_act());
-        lv_label_set_text_fmt(title, "Weighted FPS: %d", fps_weighted);
+        lv_label_set_text_fmt(title, "Weighted FPS: %"PRIu32, fps_weighted);
 
         subtitle = lv_label_create(lv_scr_act());
-        lv_label_set_text_fmt(subtitle, "Opa. speed: %d%%", opa_speed_pct);
+        lv_label_set_text_fmt(subtitle, "Opa. speed: %"PRIu32"%%", opa_speed_pct);
 
         lv_coord_t w = lv_obj_get_content_width(lv_scr_act());
         lv_obj_t * table = lv_table_create(lv_scr_act());
@@ -788,7 +788,7 @@ static void scene_next_task_cb(lv_timer_t * timer)
             if(scenes[i].fps_normal < 20 && scenes[i].weight >= 10) {
                 lv_table_set_cell_value(table, row, 0, scenes[i].name);
 
-                lv_snprintf(buf, sizeof(buf), "%d", scenes[i].fps_normal);
+                lv_snprintf(buf, sizeof(buf), "%"PRIu32, scenes[i].fps_normal);
                 lv_table_set_cell_value(table, row, 1, buf);
 
 //                lv_table_set_cell_type(table, row, 0, 2);
@@ -801,7 +801,7 @@ static void scene_next_task_cb(lv_timer_t * timer)
                 lv_snprintf(buf, sizeof(buf), "%s + opa", scenes[i].name);
                 lv_table_set_cell_value(table, row, 0, buf);
 
-                lv_snprintf(buf, sizeof(buf), "%d", scenes[i].fps_opa);
+                lv_snprintf(buf, sizeof(buf), "%"PRIu32, scenes[i].fps_opa);
                 lv_table_set_cell_value(table, row, 1, buf);
 
 //                lv_table_set_cell_type(table, row, 0, 2);
@@ -826,7 +826,7 @@ static void scene_next_task_cb(lv_timer_t * timer)
         for(i = 0; i < sizeof(scenes) / sizeof(scene_dsc_t) - 1; i++) {
             lv_table_set_cell_value(table, row, 0, scenes[i].name);
 
-            lv_snprintf(buf, sizeof(buf), "%d", scenes[i].fps_normal);
+            lv_snprintf(buf, sizeof(buf), "%"PRIu32, scenes[i].fps_normal);
             lv_table_set_cell_value(table, row, 1, buf);
 
             if(scenes[i].fps_normal < 10) {
@@ -843,7 +843,7 @@ static void scene_next_task_cb(lv_timer_t * timer)
             lv_snprintf(buf, sizeof(buf), "%s + opa", scenes[i].name);
             lv_table_set_cell_value(table, row, 0, buf);
 
-            lv_snprintf(buf, sizeof(buf), "%d", scenes[i].fps_opa);
+            lv_snprintf(buf, sizeof(buf), "%"PRIu32, scenes[i].fps_opa);
             lv_table_set_cell_value(table, row, 1, buf);
 
 

--- a/src/lv_demo_music/lv_demo_music_list.c
+++ b/src/lv_demo_music/lv_demo_music_list.c
@@ -154,7 +154,7 @@ static lv_obj_t * add_list_btn(lv_obj_t * parent, uint32_t track_id)
 {
     uint32_t t = _lv_demo_music_get_track_length(track_id);
     char time[32];
-    lv_snprintf(time, sizeof(time), "%d:%02d", t / 60, t % 60);
+    lv_snprintf(time, sizeof(time), "%"PRIu32":%02"PRIu32, t / 60, t % 60);
     const char * title = _lv_demo_music_get_title(track_id);
     const char * artist = _lv_demo_music_get_artist(track_id);
 

--- a/src/lv_demo_music/lv_demo_music_list.c
+++ b/src/lv_demo_music/lv_demo_music_list.c
@@ -154,7 +154,7 @@ static lv_obj_t * add_list_btn(lv_obj_t * parent, uint32_t track_id)
 {
     uint32_t t = _lv_demo_music_get_track_length(track_id);
     char time[32];
-    lv_snprintf(time, sizeof(time), "%"PRIu32":%02"PRIu32, t / 60, t % 60);
+    lv_snprintf(time, sizeof(time), "%"LV_PRIu32":%02"LV_PRIu32, t / 60, t % 60);
     const char * title = _lv_demo_music_get_title(track_id);
     const char * artist = _lv_demo_music_get_artist(track_id);
 

--- a/src/lv_demo_music/lv_demo_music_main.c
+++ b/src/lv_demo_music/lv_demo_music_main.c
@@ -951,7 +951,7 @@ static void next_click_event_cb(lv_event_t * e)
 static void timer_cb(lv_timer_t * t)
 {
     time_act++;
-    lv_label_set_text_fmt(time_obj, "%d:%02d", time_act / 60, time_act % 60);
+    lv_label_set_text_fmt(time_obj, "%"PRIu32":%02"PRIu32, time_act / 60, time_act % 60);
     lv_slider_set_value(slider_obj, time_act, LV_ANIM_ON);
 }
 

--- a/src/lv_demo_music/lv_demo_music_main.c
+++ b/src/lv_demo_music/lv_demo_music_main.c
@@ -951,7 +951,7 @@ static void next_click_event_cb(lv_event_t * e)
 static void timer_cb(lv_timer_t * t)
 {
     time_act++;
-    lv_label_set_text_fmt(time_obj, "%"PRIu32":%02"PRIu32, time_act / 60, time_act % 60);
+    lv_label_set_text_fmt(time_obj, "%"LV_PRIu32":%02"LV_PRIu32, time_act / 60, time_act % 60);
     lv_slider_set_value(slider_obj, time_act, LV_ANIM_ON);
 }
 

--- a/src/lv_demo_widgets/lv_demo_widgets.c
+++ b/src/lv_demo_widgets/lv_demo_widgets.c
@@ -1259,7 +1259,7 @@ static void slider_event_cb(lv_event_t * e)
         lv_obj_draw_part_dsc_t * dsc = lv_event_get_param(e);
         if(dsc->part == LV_PART_KNOB && lv_obj_has_state(obj, LV_STATE_PRESSED)) {
             char buf[8];
-            lv_snprintf(buf, sizeof(buf), "%d", lv_slider_get_value(obj));
+            lv_snprintf(buf, sizeof(buf), "%"PRId32, lv_slider_get_value(obj));
 
             lv_point_t text_size;
             lv_txt_get_size(&text_size, buf, font_normal, 0, 0, LV_COORD_MAX, LV_TEXT_FLAG_NONE);
@@ -1363,7 +1363,7 @@ static void chart_event_cb(lv_event_t * e)
                 }
 
                 char buf[8];
-                lv_snprintf(buf, sizeof(buf), "%d", dsc->value);
+                lv_snprintf(buf, sizeof(buf), "%"PRIu32, dsc->value);
 
                 lv_point_t text_size;
                 lv_txt_get_size(&text_size, buf, font_normal, 0, 0, LV_COORD_MAX, LV_TEXT_FLAG_NONE);
@@ -1470,7 +1470,7 @@ static void meter1_indic1_anim_cb(void * var, int32_t v)
 
     lv_obj_t * card = lv_obj_get_parent(meter1);
     lv_obj_t * label = lv_obj_get_child(card, -5);
-    lv_label_set_text_fmt(label, "Revenue: %d %%", v);
+    lv_label_set_text_fmt(label, "Revenue: %"PRId32" %%", v);
 }
 
 static void meter1_indic2_anim_cb(void * var, int32_t v)
@@ -1479,7 +1479,7 @@ static void meter1_indic2_anim_cb(void * var, int32_t v)
 
     lv_obj_t * card = lv_obj_get_parent(meter1);
     lv_obj_t * label = lv_obj_get_child(card, -3);
-    lv_label_set_text_fmt(label, "Sales: %d %%", v);
+    lv_label_set_text_fmt(label, "Sales: %"PRId32" %%", v);
 
 }
 
@@ -1489,7 +1489,7 @@ static void meter1_indic3_anim_cb(void * var, int32_t v)
 
     lv_obj_t * card = lv_obj_get_parent(meter1);
     lv_obj_t * label = lv_obj_get_child(card, -1);
-    lv_label_set_text_fmt(label, "Costs: %d %%", v);
+    lv_label_set_text_fmt(label, "Costs: %"PRId32" %%", v);
 }
 
 static void meter2_timer_cb(lv_timer_t * timer)
@@ -1542,13 +1542,13 @@ static void meter2_timer_cb(lv_timer_t * timer)
     lv_obj_t * label;
 
     label = lv_obj_get_child(card, -5);
-    lv_label_set_text_fmt(label, "Desktop: %d", session_desktop);
+    lv_label_set_text_fmt(label, "Desktop: %"PRIu32, session_desktop);
 
     label = lv_obj_get_child(card, -3);
-    lv_label_set_text_fmt(label, "Tablet: %d", session_tablet);
+    lv_label_set_text_fmt(label, "Tablet: %"PRIu32, session_tablet);
 
     label = lv_obj_get_child(card, -1);
-    lv_label_set_text_fmt(label, "Mobile: %d", session_mobile);
+    lv_label_set_text_fmt(label, "Mobile: %"PRIu32, session_mobile);
 }
 
 static void meter3_anim_cb(void * var, int32_t v)
@@ -1556,7 +1556,7 @@ static void meter3_anim_cb(void * var, int32_t v)
     lv_meter_set_indicator_value(meter3, var, v);
 
     lv_obj_t * label = lv_obj_get_child(meter3, 0);
-    lv_label_set_text_fmt(label, "%d", v);
+    lv_label_set_text_fmt(label, "%"PRId32, v);
 }
 
 #endif

--- a/src/lv_demo_widgets/lv_demo_widgets.c
+++ b/src/lv_demo_widgets/lv_demo_widgets.c
@@ -1259,7 +1259,7 @@ static void slider_event_cb(lv_event_t * e)
         lv_obj_draw_part_dsc_t * dsc = lv_event_get_param(e);
         if(dsc->part == LV_PART_KNOB && lv_obj_has_state(obj, LV_STATE_PRESSED)) {
             char buf[8];
-            lv_snprintf(buf, sizeof(buf), "%"PRId32, lv_slider_get_value(obj));
+            lv_snprintf(buf, sizeof(buf), "%"LV_PRId32, lv_slider_get_value(obj));
 
             lv_point_t text_size;
             lv_txt_get_size(&text_size, buf, font_normal, 0, 0, LV_COORD_MAX, LV_TEXT_FLAG_NONE);
@@ -1363,7 +1363,7 @@ static void chart_event_cb(lv_event_t * e)
                 }
 
                 char buf[8];
-                lv_snprintf(buf, sizeof(buf), "%"PRIu32, dsc->value);
+                lv_snprintf(buf, sizeof(buf), "%"LV_PRIu32, dsc->value);
 
                 lv_point_t text_size;
                 lv_txt_get_size(&text_size, buf, font_normal, 0, 0, LV_COORD_MAX, LV_TEXT_FLAG_NONE);
@@ -1470,7 +1470,7 @@ static void meter1_indic1_anim_cb(void * var, int32_t v)
 
     lv_obj_t * card = lv_obj_get_parent(meter1);
     lv_obj_t * label = lv_obj_get_child(card, -5);
-    lv_label_set_text_fmt(label, "Revenue: %"PRId32" %%", v);
+    lv_label_set_text_fmt(label, "Revenue: %"LV_PRId32" %%", v);
 }
 
 static void meter1_indic2_anim_cb(void * var, int32_t v)
@@ -1479,7 +1479,7 @@ static void meter1_indic2_anim_cb(void * var, int32_t v)
 
     lv_obj_t * card = lv_obj_get_parent(meter1);
     lv_obj_t * label = lv_obj_get_child(card, -3);
-    lv_label_set_text_fmt(label, "Sales: %"PRId32" %%", v);
+    lv_label_set_text_fmt(label, "Sales: %"LV_PRId32" %%", v);
 
 }
 
@@ -1489,7 +1489,7 @@ static void meter1_indic3_anim_cb(void * var, int32_t v)
 
     lv_obj_t * card = lv_obj_get_parent(meter1);
     lv_obj_t * label = lv_obj_get_child(card, -1);
-    lv_label_set_text_fmt(label, "Costs: %"PRId32" %%", v);
+    lv_label_set_text_fmt(label, "Costs: %"LV_PRId32" %%", v);
 }
 
 static void meter2_timer_cb(lv_timer_t * timer)
@@ -1542,13 +1542,13 @@ static void meter2_timer_cb(lv_timer_t * timer)
     lv_obj_t * label;
 
     label = lv_obj_get_child(card, -5);
-    lv_label_set_text_fmt(label, "Desktop: %"PRIu32, session_desktop);
+    lv_label_set_text_fmt(label, "Desktop: %"LV_PRIu32, session_desktop);
 
     label = lv_obj_get_child(card, -3);
-    lv_label_set_text_fmt(label, "Tablet: %"PRIu32, session_tablet);
+    lv_label_set_text_fmt(label, "Tablet: %"LV_PRIu32, session_tablet);
 
     label = lv_obj_get_child(card, -1);
-    lv_label_set_text_fmt(label, "Mobile: %"PRIu32, session_mobile);
+    lv_label_set_text_fmt(label, "Mobile: %"LV_PRIu32, session_mobile);
 }
 
 static void meter3_anim_cb(void * var, int32_t v)
@@ -1556,7 +1556,7 @@ static void meter3_anim_cb(void * var, int32_t v)
     lv_meter_set_indicator_value(meter3, var, v);
 
     lv_obj_t * label = lv_obj_get_child(meter3, 0);
-    lv_label_set_text_fmt(label, "%"PRId32, v);
+    lv_label_set_text_fmt(label, "%"LV_PRId32, v);
 }
 
 #endif


### PR DESCRIPTION
Changed format strings in examples to use macros
* `PRId32` for `int32_t`
* `PRIu32` for `uint32_t`

instead of `"%d"` which generated warnings with `-WFormat` set